### PR TITLE
Fix jsx types

### DIFF
--- a/attributes.ts
+++ b/attributes.ts
@@ -98,15 +98,13 @@ type MediaStream = any; // TODO:
 /** list of all allowed attributes for HTML elements */
 export const htmlElementAttributes = {
 
-	// TODO replace valueOut, ... with value:out
-
 	a: [...href, "target"],
 	link: [...href, "rel"],
 
 	script: [...src, "type"],
 
 	progress: ["value", "max", "min"],
-	input: [alt, ...src, alt, ...widthAndHeight, "min", "minlength", "accept", "autocomplete", "autofocus", "checked", "dirname", "disabled", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "list", "max", "maxlength", "multiple", "name", "pattern", "placeholder", "readonly", "required", "size", "step", "type", "value", "valueOut", "valueInitial"],
+	input: [alt, ...src, alt, ...widthAndHeight, "min", "minlength", "accept", "autocomplete", "autofocus", "checked", "dirname", "disabled", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "list", "max", "maxlength", "multiple", "name", "pattern", "placeholder", "readonly", "required", "size", "step", "type", "value", "value:out"],
 	button: ["type", "disabled"],
 	form: ["method", "enctype", "action"],
 	img: [alt, ...src, ...widthAndHeight, "border", "crossorigin", "ismap", "loading", "longdesc", "referrerpolicy", "sizes", "srcset", "usemap"],

--- a/attributes.ts
+++ b/attributes.ts
@@ -34,7 +34,7 @@ export const defaultElementAttributes = [
 	"accesskey", "class", "contenteditable", "contextmenu", "dir", "draggable", "dropzone", "hidden", "id", "lang", "spellcheck", "style", "tabindex", "title",
 	"role", "name", "slot",
 	// uix specific
-	"uix-module", 
+	"uix-module", "stylesheet",
 	"datex-pointer", "datex-update",
 	"shadow-root", "display"
 ] as const;
@@ -43,6 +43,7 @@ export const defaultElementAttributes = [
 // custom attribute values for default attributes (default: string)
 type customDefaultAttributeValues = {
 	"uix-module": string|URL|null,
+	"stylesheet": string|URL|null,
 	"shadow-root": boolean|'open'|'closed',
 	"datex-pointer": boolean,
 	"datex-update": "onchange"|"onsubmit"

--- a/datex-bindings/dom-utils.ts
+++ b/datex-bindings/dom-utils.ts
@@ -523,6 +523,11 @@ export class DOMUtils {
             (<DOMUtils.elWithEventListeners><unknown>element)[DOMUtils.DATEX_UPDATE_TYPE] = val as string;
         }
 
+        // set stylesheet
+        else if (attr == "stylesheet") {
+            element.append(this.createHTMLElement(`<link rel="stylesheet" href="${this.formatAttributeValue(val, root_path)}?scope"/>`))
+        }
+
         // update checkbox checked property (bug?)
         else if (element instanceof this.context.HTMLDialogElement && attr == "open") {
 
@@ -662,9 +667,12 @@ export class DOMUtils {
         }
         else properties = Datex.Ref.collapseValue(properties_object_or_property,true,true) as {[property:string]:Datex.CompatValue<string|number|undefined>};
 
-        for (const [property, value] of Object.entries(properties)) {
-            this.setCSSProperty(element, property, value);
+        if (properties) {
+            for (const [property, value] of Object.entries(properties)) {
+                this.setCSSProperty(element, property, value);
+            }
         }
+
         return element;
     }
 

--- a/jsx/jsx-definitions.ts
+++ b/jsx/jsx-definitions.ts
@@ -3,7 +3,7 @@ import type { validHTMLElementAttrs, validHTMLElementSpecificAttrs, validSVGElem
 import type { HTMLElement, DocumentFragment } from "../dom/mod.ts";
 import { HTMLElementTagNameMap, SVGElementTagNameMap } from "../dom/deno-dom/src/dom/types/tags.ts";
 
-type DomElement = HTMLElement // TODO: Element?
+type DomElement = Element;// HTMLElement // TODO: Element?
 
 
 type RefOrValueUnion<U> = (U extends any ? Datex.RefOrValue<U> : never)
@@ -47,7 +47,18 @@ declare global {
 		// interface IntrinsicClassAttributes<C extends Component> {}
 
 		type DatexValueObject<T extends Record<string|symbol,unknown>, allowPromises extends boolean = false> = {
-			[key in keyof T]: T[key] extends (...args:unknown[])=>unknown ? T[key] : (T[key] extends boolean ? Datex.RefOrValue<T[key]> : RefOrValueUnion<T[key]>)|(allowPromises extends true ? Promise<(T[key] extends boolean ? Datex.RefOrValue<T[key]> : RefOrValueUnion<T[key]>)> : never)
+			[key in keyof T]: T[key] extends (...args:unknown[])=>unknown ? 
+				T[key] : 
+				(T[key] extends boolean ? 
+					Datex.RefOrValue<T[key]> : 
+					(undefined extends T[key] ?
+						Datex.RefOrValue<T[key]> : 
+						RefOrValueUnion<T[key]>
+					)
+					
+				) | (
+					allowPromises extends true ? Promise<(T[key] extends boolean ? Datex.RefOrValue<T[key]> : RefOrValueUnion<T[key]>)> : never
+				)
 		}
 		
 		type IntrinsicElements = 

--- a/jsx/parser.ts
+++ b/jsx/parser.ts
@@ -12,6 +12,7 @@ const logger = new Logger("JSX Parser");
 
 export const SET_DEFAULT_ATTRIBUTES: unique symbol = Symbol("SET_DEFAULT_ATTRIBUTES");
 export const SET_DEFAULT_CHILDREN: unique symbol = Symbol("SET_DEFAULT_CHILDREN");
+export const IS_TEMPLATE: unique symbol = Symbol("IS_TEMPLATE");
 
 
 export function escapeString(string:string) {
@@ -99,9 +100,18 @@ export function getParseJSX(context: DOMContext, domUtils: DOMUtils) {
 	function parseJSX(type: string | typeof Element | typeof DocumentFragment | ((...args:unknown[])=>Element|DocumentFragment), params: Record<string,unknown>, isJSXS = false): Element {
 
 		Datex.Ref.freezeCapturing = true;
+		const isTemplate = (type as any)[IS_TEMPLATE] ?? false;
+		const isComponent = typeof type == "function" && (context.HTMLElement.isPrototypeOf(type) || type === context.DocumentFragment || context.DocumentFragment.isPrototypeOf(type))
 
 		let element:Element;
-		if ('children' in params && !(params.children instanceof Array)) params.children = [params.children];
+
+		// normalize children if template/blankTemplate or component - not for plain functions
+		if (isTemplate || isComponent) {
+			// always convert children prop to array
+			if ('children' in params && !(params.children instanceof Array)) params.children = [params.children];
+			// always set children prop to empty array if not defined
+			if (!('children' in params)) params.children = [];
+		}
 		const { children = [], ...props } = params as Record<string,unknown> & {children:JSX.singleChild[]}
 	
 		// _debug property to debug jsx
@@ -126,7 +136,7 @@ export function getParseJSX(context: DOMContext, domUtils: DOMUtils) {
 		if (typeof type === 'function') {
 	
 			// class component
-			if (context.HTMLElement.isPrototypeOf(type) || type === context.DocumentFragment || context.DocumentFragment.isPrototypeOf(type)) {
+			if (isComponent) {
 				set_default_children = (type as any)[SET_DEFAULT_CHILDREN] ?? true;
 				set_default_attributes = (type as any)[SET_DEFAULT_ATTRIBUTES] ?? true;
 				if (set_default_children) delete params.children;

--- a/jsx/parser.ts
+++ b/jsx/parser.ts
@@ -53,11 +53,23 @@ export function getParseJSX(context: DOMContext, domUtils: DOMUtils) {
 		if (set_default_children) setChildren(element, children, shadow_root);
 
 		if (set_default_attributes) {
-			let module = ((<Record<string,unknown>>props)['module'] ?? (<Record<string,unknown>>props)['uix-module']) as string|undefined;
+			let module = ((<Record<string,unknown>>props)['module'] ?? (<Record<string,unknown>>props)['uix-module']) as string|null;
 			// ignore module of is explicitly module===null, otherwise fallback to getCallerFile
 			// TODO: optimize don't call getCallerFile for each nested jsx element, pass on from parent?
 			if (module === undefined) {
-				module = callerModule ?? getCallerInfo()?.[1]?.file!;
+				// module already determined
+				if (callerModule) module = callerModule;
+				// get caller module
+				else {
+					const stack = getCallerInfo();
+					if (stack) {
+						module = (
+							stack[1].name == "jsxs" ? // called via jsxs, skip one more in stack
+								stack[2] : 
+								stack[1]
+							)?.file;
+					}
+				}
 				if (!module) {
 					logger.error("Could not determine location of JSX definition")
 				}


### PR DESCRIPTION
* Always returns an empty array for the `children` prop in `blankTemplate` (not in raw component functions)
* Fixes optional props types