### PR TITLE
Fix types

### DIFF
--- a/attributes.ts
+++ b/attributes.ts
@@ -109,7 +109,7 @@ export const htmlElementAttributes = {
 	form: ["method", "enctype", "action"],
 	img: [alt, ...src, ...widthAndHeight, "border", "crossorigin", "ismap", "loading", "longdesc", "referrerpolicy", "sizes", "srcset", "usemap"],
 	template: ["shadowrootmode"],
-	iframe: [...src, "allowtransparency"],
+	iframe: [...src, "allowtransparency", "allow"],
 	details: ["open"],
 	source: [...src, "type"],
 	label: ["for"],

--- a/jsx/jsx-definitions.ts
+++ b/jsx/jsx-definitions.ts
@@ -2,6 +2,7 @@ import type { Datex } from "datex-core-legacy/datex.ts";
 import type { validHTMLElementAttrs, validHTMLElementSpecificAttrs, validSVGElementSpecificAttrs } from "../attributes.ts";
 import type { HTMLElement, DocumentFragment } from "../dom/mod.ts";
 import { HTMLElementTagNameMap, SVGElementTagNameMap } from "../dom/deno-dom/src/dom/types/tags.ts";
+import type {Element} from "../dom/deno-dom/src/api.ts"
 
 type DomElement = Element;// HTMLElement // TODO: Element?
 
@@ -11,7 +12,7 @@ type RefOrValueUnion<U> = (U extends any ? Datex.RefOrValue<U> : never)
 declare global {
 	namespace JSX {
 		// JSX node definition
-		type Element = DomElement|DocumentFragment
+		type Element = DomElement
 		type ElementType = string|{new(): Element}|((props?:any, propsValues?:any)=>Element)|((props?:any, propsValues?:any)=>Promise<Element>)
 
 		// type ElementClass = typeof Element


### PR DESCRIPTION
Fixes more JSX type problems.
The "dom" lib can now also be used (in deno.json) without JSX type errors.